### PR TITLE
Added conflict with `container-interop/container-interop < 1.2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
         "phpunit/phpunit": "^5.7.22 || ^6.3.1",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
+    "conflict": {
+        "container-interop/container-interop": "<1.2.0"
+    },
     "autoload": {
         "psr-4": {
             "Zend\\AuraDi\\Config\\": "src"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c959b3e69bc9728793fff7ca8122bd95",
+    "content-hash": "d28d674cec531bbf6baefca027635742",
     "packages": [
         {
             "name": "aura/di",


### PR DESCRIPTION
From 1.2.0 `container-interop/container-interop` extends `psr/container` and we want to use PSR-11 container in the library.

Before tests with lowest dependencies were failing.