### PR TITLE
Ensure service name is passed to factories as the second argument

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -90,7 +90,7 @@ class Config implements ContainerConfigInterface
                 if (! $container->has($factory)) {
                     $container->set($factory, $container->lazyNew($factory));
                 }
-                $container->set($service, $container->lazyGetCall($factory, '__invoke', $container));
+                $container->set($service, $container->lazyGetCall($factory, '__invoke', $container, $service));
             }
         }
 

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -212,4 +212,30 @@ class ConfigTest extends TestCase
             $service->injected
         );
     }
+
+    public function testFactoryGetsServiceName()
+    {
+        $factory = new class {
+            public function __invoke()
+            {
+                return func_get_args();
+            }
+        };
+
+        $dependencies = [
+            'services'  => [
+                'factory' => $factory,
+            ],
+            'factories' => [
+                'foo-bar' => 'factory',
+            ],
+        ];
+
+        $container = $this->builder->newConfiguredInstance([new Config(['dependencies' => $dependencies])]);
+        $args = $container->get('foo-bar');
+
+        self::assertCount(2, $args);
+        self::assertSame($container, array_shift($args));
+        self::assertEquals('foo-bar', array_shift($args));
+    }
 }

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -10,6 +10,7 @@ namespace ZendTest\AuraDi\Config;
 use Aura\Di\ContainerBuilder;
 use PHPUnit\Framework\TestCase;
 use Zend\AuraDi\Config\Config;
+use ZendTest\AuraDi\Config\TestAsset\FactoryWithName;
 
 class ConfigTest extends TestCase
 {
@@ -215,12 +216,7 @@ class ConfigTest extends TestCase
 
     public function testFactoryGetsServiceName()
     {
-        $factory = new class {
-            public function __invoke()
-            {
-                return func_get_args();
-            }
-        };
+        $factory = new FactoryWithName();
 
         $dependencies = [
             'services'  => [

--- a/test/TestAsset/FactoryWithName.php
+++ b/test/TestAsset/FactoryWithName.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-auradi-config for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-auradi-config/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\AuraDi\Config\TestAsset;
+
+class FactoryWithName
+{
+    public function __invoke()
+    {
+        return func_get_args();
+    }
+}


### PR DESCRIPTION
This update ensures factories get the service name as the second argument when invoked, in case the factory implements `Zend\ServiceManager\Factory\FactoryInterface` or `Zend\ServiceManager\Factory\AbstractFactoryInterface`, and therefore the second argument is not optional.

It also makes sense if the factory is being used to create multiple services.
