### PR TITLE
Fixed invokable configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ The `dependencies` sub associative array can contain the following keys:
 - `services`: an associative array that maps a key to a specific service instance.
 - `invokables`: an associative array that map a key to a constructor-less
   service; i.e., for services that do not require arguments to the constructor.
-  The key and service name may be the same; if they are not, the name is treated
-  as an alias.
+  The key and service name usually are the same; if they are not, the key is
+  treated as an alias.
 - `factories`: an associative array that maps a service name to a factory class
   name, or any callable. Factory classes must be instantiable without arguments,
   and callable once instantiated (i.e., implement the `__invoke()` method).

--- a/src/Config.php
+++ b/src/Config.php
@@ -99,7 +99,11 @@ class Config implements ContainerConfigInterface
             && is_array($dependencies['invokables'])
         ) {
             foreach ($dependencies['invokables'] as $service => $class) {
-                $container->set($service, $container->lazyNew($class));
+                if ($service !== $class) {
+                    $container->set($service, $container->lazyGet($class));
+                }
+
+                $container->set($class, $container->lazyNew($class));
             }
         }
 

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -234,4 +234,39 @@ class ConfigTest extends TestCase
         self::assertSame($container, array_shift($args));
         self::assertEquals('foo-bar', array_shift($args));
     }
+
+    public function testInvokableWithAlias()
+    {
+        $dependencies = [
+            'invokables' => [
+                TestAsset\Service::class,
+            ],
+        ];
+
+        $container = $this->builder->newConfiguredInstance([new Config(['dependencies' => $dependencies])]);
+
+        self::assertTrue($container->has(TestAsset\Service::class));
+        $service = $container->get(TestAsset\Service::class);
+        self::assertInstanceOf(TestAsset\Service::class, $service);
+        self::assertTrue($container->has('0'));
+    }
+
+    public function testInvokableWithoutAlias()
+    {
+        $dependencies = [
+            'invokables' => [
+                'alias' => TestAsset\Service::class,
+            ],
+        ];
+
+        $container = $this->builder->newConfiguredInstance([new Config(['dependencies' => $dependencies])]);
+
+        self::assertTrue($container->has('alias'));
+        $service = $container->get('alias');
+        self::assertInstanceOf(TestAsset\Service::class, $service);
+        self::assertTrue($container->has(TestAsset\Service::class));
+        $originService = $container->get(TestAsset\Service::class);
+        self::assertInstanceOf(TestAsset\Service::class, $originService);
+        self::assertSame($service, $originService);
+    }
 }

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -235,7 +235,7 @@ class ConfigTest extends TestCase
         self::assertEquals('foo-bar', array_shift($args));
     }
 
-    public function testInvokableWithAlias()
+    public function testInvokableWithoutAlias()
     {
         $dependencies = [
             'invokables' => [
@@ -251,7 +251,7 @@ class ConfigTest extends TestCase
         self::assertTrue($container->has('0'));
     }
 
-    public function testInvokableWithoutAlias()
+    public function testInvokableWithAlias()
     {
         $dependencies = [
             'invokables' => [


### PR DESCRIPTION
We need provide invokables as associative array with keys and values.
Key is usally the same as service name, if it is not, the alias is created.

The same behaviour we have in zend-servicemanager.