### PR TITLE
ServiceManager config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ The `dependencies` sub associative array can contain the following keys:
 - `services`: an associative array that maps a key to a specific service instance.
 - `invokables`: an associative array that map a key to a constructor-less
   service; i.e., for services that do not require arguments to the constructor.
-  The key and service name may be the same; if they are not, the name is treated
-  as an alias.
+  The key and service name usually are the same; if they are not, the key is
+  treated as an alias.
 - `factories`: an associative array that maps a service name to a factory class
   name, or any callable. Factory classes must be instantiable without arguments,
   and callable once instantiated (i.e., implement the `__invoke()` method).

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,16 @@
         "aura/di": "^3.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5.4",
-        "zendframework/zend-coding-standard": "~1.0.0"
+        "phpunit/phpunit": "^7.0.1",
+        "zendframework/zend-coding-standard": "~1.0.0",
+        "zendframework/zend-container-test": "dev-master"
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-container-test"
+        }
+    ],
     "conflict": {
         "container-interop/container-interop": "<1.2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a5c17c81ac742cc0d8f406c69a4df15",
+    "content-hash": "653d895219fe86ce66c8a7d85fd13c86",
     "packages": [
         {
             "name": "aura/di",
@@ -398,16 +398,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.2.0",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
@@ -445,7 +445,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-27T17:38:31+00:00"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -496,16 +496,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.3",
+            "version": "1.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
                 "shasum": ""
             },
             "require": {
@@ -517,7 +517,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
             },
             "type": "library",
             "extra": {
@@ -555,44 +555,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-11-24T13:59:53+00:00"
+            "time": "2018-02-19T10:16:54+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
+                "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-xdebug": "^2.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "6.0-dev"
                 }
             },
             "autoload": {
@@ -618,7 +618,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-06T09:29:45+00:00"
+            "time": "2018-02-02T07:01:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -710,28 +710,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -746,7 +746,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -755,33 +755,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2018-02-01T13:07:23+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -804,20 +804,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2018-02-01T13:16:43+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.4",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1b2f933d5775f9237369deaa2d2bfbf9d652be4c"
+                "reference": "316555dbd0ed4097bbdd17c65ab416bf27a472e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1b2f933d5775f9237369deaa2d2bfbf9d652be4c",
-                "reference": "1b2f933d5775f9237369deaa2d2bfbf9d652be4c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/316555dbd0ed4097bbdd17c65ab416bf27a472e9",
+                "reference": "316555dbd0ed4097bbdd17c65ab416bf27a472e9",
                 "shasum": ""
             },
             "require": {
@@ -829,15 +829,15 @@
                 "myclabs/deep-copy": "^1.6.1",
                 "phar-io/manifest": "^1.0.1",
                 "phar-io/version": "^1.0",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-code-coverage": "^6.0",
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "phpunit/php-timer": "^2.0",
+                "phpunit/phpunit-mock-objects": "^6.0",
                 "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^2.0",
+                "sebastian/diff": "^3.0",
                 "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
@@ -845,16 +845,12 @@
                 "sebastian/resource-operations": "^1.0",
                 "sebastian/version": "^2.0.1"
             },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
-            },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "phpunit/php-invoker": "^2.0"
             },
             "bin": [
                 "phpunit"
@@ -862,7 +858,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5.x-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -888,33 +884,30 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-10T08:06:19+00:00"
+            "time": "2018-02-13T06:08:08+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.5",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "283b9f4f670e3a6fd6c4ff95c51a952eb5c75933"
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/283b9f4f670e3a6fd6c4ff95c51a952eb5c75933",
-                "reference": "283b9f4f670e3a6fd6c4ff95c51a952eb5c75933",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpunit/php-text-template": "^1.2.1",
                 "sebastian/exporter": "^3.1"
             },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
             "require-dev": {
-                "phpunit/phpunit": "^6.5"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -922,7 +915,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0.x-dev"
+                    "dev-master": "6.0.x-dev"
                 }
             },
             "autoload": {
@@ -947,7 +940,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-12-10T08:01:53+00:00"
+            "time": "2018-02-15T05:27:38+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -996,21 +989,21 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.0",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1174d9018191e93cb9d719edec01257fc05f8158"
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1174d9018191e93cb9d719edec01257fc05f8158",
-                "reference": "1174d9018191e93cb9d719edec01257fc05f8158",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "sebastian/diff": "^2.0",
+                "sebastian/diff": "^2.0 || ^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
@@ -1056,32 +1049,33 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-11-03T07:16:52+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^7.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1106,9 +1100,12 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "time": "2018-02-01T13:45:15+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1628,16 +1625,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -1674,7 +1671,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-01-29T19:49:41+00:00"
         },
         {
             "name": "zendframework/zend-coding-standard",
@@ -1704,11 +1701,91 @@
                 "zf"
             ],
             "time": "2016-11-09T21:30:43+00:00"
+        },
+        {
+            "name": "zendframework/zend-container-test",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/zend-container-test",
+                "reference": "a72dd5012f9bebe04d5c94d8c372cc83d27a2204"
+            },
+            "require": {
+                "php": "^7.1",
+                "psr/container": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0",
+                "zendframework/zend-auradi-config": "^1.0.0alpha1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-pimple-config": "^1.0.0alpha1",
+                "zendframework/zend-servicemanager": "^3.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "zf": {
+                    "config-provider": "Zend\\ContainerTest\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\ContainerTest\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\ContainerTest\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ]
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "PSR-11 Container common test cases",
+            "keywords": [
+                "components",
+                "container",
+                "psr-11",
+                "test",
+                "zendframework",
+                "zf"
+            ],
+            "support": {
+                "docs": "https://docs.zendframework.com/zend-container-test/",
+                "issues": "https://github.com/zendframework/zend-container-test/issues",
+                "source": "https://github.com/zendframework/zend-container-test",
+                "rss": "https://github.com/zendframework/zend-container-test/releases.atom",
+                "slack": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/components"
+            },
+            "time": "2018-02-20T08:31:21+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-container-test": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -1708,7 +1708,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/zend-container-test",
-                "reference": "a72dd5012f9bebe04d5c94d8c372cc83d27a2204"
+                "reference": "e0a318601e2a6aac636d9979ae8f2c851f75233e"
             },
             "require": {
                 "php": "^7.1",
@@ -1778,7 +1778,7 @@
                 "slack": "https://zendframework-slack.herokuapp.com",
                 "forum": "https://discourse.zendframework.com/c/questions/components"
             },
-            "time": "2018-02-20T08:31:21+00:00"
+            "time": "2018-02-20T11:07:46+00:00"
         }
     ],
     "aliases": [],

--- a/src/Config.php
+++ b/src/Config.php
@@ -101,7 +101,11 @@ class Config implements ContainerConfigInterface
             && is_array($dependencies['invokables'])
         ) {
             foreach ($dependencies['invokables'] as $service => $class) {
-                $container->set($service, $container->lazyNew($class));
+                if ($service !== $class) {
+                    $container->set($service, $container->lazyGet($class));
+                }
+
+                $container->set($class, $container->lazyNew($class));
             }
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -12,6 +12,7 @@ namespace Zend\AuraDi\Config;
 use ArrayObject;
 use Aura\Di\Container;
 use Aura\Di\ContainerConfigInterface;
+use Aura\Di\Exception\ServiceNotFound;
 
 /**
  * Configuration for the Aura.Di container.
@@ -89,10 +90,22 @@ class Config implements ContainerConfigInterface
             && is_array($dependencies['factories'])
         ) {
             foreach ($dependencies['factories'] as $service => $factory) {
-                if (! $container->has($factory)) {
-                    $container->set($factory, $container->lazyNew($factory));
+                if (is_callable($factory)) {
+                    $container->set($service, $container->lazy($factory, $container, $service));
+                    continue;
                 }
-                $container->set($service, $container->lazyGetCall($factory, '__invoke', $container, $service));
+
+                $container->set($service, $container->lazy(function ($container, $service) use ($factory) {
+                    if (! class_exists($factory)) {
+                        throw new ServiceNotFound(sprintf(
+                            'Service %s cannot be initialized by factory %s',
+                            $service,
+                            $factory
+                        ));
+                    }
+
+                    return (new $factory())($container, $service);
+                }, $container, $service));
             }
         }
 

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -236,39 +236,4 @@ class ConfigTest extends TestCase
         self::assertSame($container, array_shift($args));
         self::assertEquals('foo-bar', array_shift($args));
     }
-
-    public function testInvokableWithoutAlias()
-    {
-        $dependencies = [
-            'invokables' => [
-                TestAsset\Service::class,
-            ],
-        ];
-
-        $container = $this->builder->newConfiguredInstance([new Config(['dependencies' => $dependencies])]);
-
-        self::assertTrue($container->has(TestAsset\Service::class));
-        $service = $container->get(TestAsset\Service::class);
-        self::assertInstanceOf(TestAsset\Service::class, $service);
-        self::assertTrue($container->has('0'));
-    }
-
-    public function testInvokableWithAlias()
-    {
-        $dependencies = [
-            'invokables' => [
-                'alias' => TestAsset\Service::class,
-            ],
-        ];
-
-        $container = $this->builder->newConfiguredInstance([new Config(['dependencies' => $dependencies])]);
-
-        self::assertTrue($container->has('alias'));
-        $service = $container->get('alias');
-        self::assertInstanceOf(TestAsset\Service::class, $service);
-        self::assertTrue($container->has(TestAsset\Service::class));
-        $originService = $container->get(TestAsset\Service::class);
-        self::assertInstanceOf(TestAsset\Service::class, $originService);
-        self::assertSame($service, $originService);
-    }
 }

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-auradi-config for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-auradi-config/blob/master/LICENSE.md New BSD License
  */
 
@@ -12,7 +12,6 @@ namespace ZendTest\AuraDi\Config;
 use Aura\Di\ContainerBuilder;
 use PHPUnit\Framework\TestCase;
 use Zend\AuraDi\Config\Config;
-use ZendTest\AuraDi\Config\TestAsset\FactoryWithName;
 
 class ConfigTest extends TestCase
 {
@@ -52,54 +51,6 @@ class ConfigTest extends TestCase
 
         self::assertTrue($container->has('foo-bar'));
         self::assertSame($myService, $container->get('foo-bar'));
-    }
-
-    public function testInjectServiceFactory()
-    {
-        $factory = new TestAsset\Factory();
-
-        $dependencies = [
-            'services'  => [
-                'factory' => $factory,
-            ],
-            'factories' => [
-                'foo-bar' => 'factory',
-            ],
-        ];
-
-        $container = $this->builder->newConfiguredInstance([new Config(['dependencies' => $dependencies])]);
-
-        self::assertTrue($container->has('factory'));
-        self::assertTrue($container->has('foo-bar'));
-        self::assertInstanceOf(TestAsset\Service::class, $container->get('foo-bar'));
-    }
-
-    public function testInjectInvokableFactory()
-    {
-        $dependencies = [
-            'factories' => [
-                'foo-bar' => TestAsset\Factory::class,
-            ],
-        ];
-
-        $container = $this->builder->newConfiguredInstance([new Config(['dependencies' => $dependencies])]);
-
-        self::assertTrue($container->has('foo-bar'));
-        self::assertInstanceOf(TestAsset\Service::class, $container->get('foo-bar'));
-    }
-
-    public function testInjectInvokable()
-    {
-        $dependencies = [
-            'invokables' => [
-                'foo-bar' => TestAsset\Service::class,
-            ],
-        ];
-
-        $container = $this->builder->newConfiguredInstance([new Config(['dependencies' => $dependencies])]);
-
-        self::assertTrue($container->has('foo-bar'));
-        self::assertInstanceOf(TestAsset\Service::class, $container->get('foo-bar'));
     }
 
     public function testInjectAlias()
@@ -214,26 +165,5 @@ class ConfigTest extends TestCase
             ],
             $service->injected
         );
-    }
-
-    public function testFactoryGetsServiceName()
-    {
-        $factory = new FactoryWithName();
-
-        $dependencies = [
-            'services'  => [
-                'factory' => $factory,
-            ],
-            'factories' => [
-                'foo-bar' => 'factory',
-            ],
-        ];
-
-        $container = $this->builder->newConfiguredInstance([new Config(['dependencies' => $dependencies])]);
-        $args = $container->get('foo-bar');
-
-        self::assertCount(2, $args);
-        self::assertSame($container, array_shift($args));
-        self::assertEquals('foo-bar', array_shift($args));
     }
 }

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -236,4 +236,39 @@ class ConfigTest extends TestCase
         self::assertSame($container, array_shift($args));
         self::assertEquals('foo-bar', array_shift($args));
     }
+
+    public function testInvokableWithoutAlias()
+    {
+        $dependencies = [
+            'invokables' => [
+                TestAsset\Service::class,
+            ],
+        ];
+
+        $container = $this->builder->newConfiguredInstance([new Config(['dependencies' => $dependencies])]);
+
+        self::assertTrue($container->has(TestAsset\Service::class));
+        $service = $container->get(TestAsset\Service::class);
+        self::assertInstanceOf(TestAsset\Service::class, $service);
+        self::assertTrue($container->has('0'));
+    }
+
+    public function testInvokableWithAlias()
+    {
+        $dependencies = [
+            'invokables' => [
+                'alias' => TestAsset\Service::class,
+            ],
+        ];
+
+        $container = $this->builder->newConfiguredInstance([new Config(['dependencies' => $dependencies])]);
+
+        self::assertTrue($container->has('alias'));
+        $service = $container->get('alias');
+        self::assertInstanceOf(TestAsset\Service::class, $service);
+        self::assertTrue($container->has(TestAsset\Service::class));
+        $originService = $container->get(TestAsset\Service::class);
+        self::assertInstanceOf(TestAsset\Service::class, $originService);
+        self::assertSame($service, $originService);
+    }
 }

--- a/test/ContainerTest.php
+++ b/test/ContainerTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-auradi-config for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-auradi-config/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\AuraDi\Config;
+
+use Psr\Container\ContainerInterface;
+use Zend\AuraDi\Config\Config;
+use Zend\AuraDi\Config\ContainerFactory;
+use Zend\ContainerTest\InvokableTestTrait;
+
+class ContainerTest extends \Zend\ContainerTest\ContainerTest
+{
+    use InvokableTestTrait;
+
+    protected function createContainer(array $config) : ContainerInterface
+    {
+        $factory = new ContainerFactory();
+
+        return $factory(new Config(['dependencies' => $config]));
+    }
+}

--- a/test/ContainerTest.php
+++ b/test/ContainerTest.php
@@ -12,10 +12,14 @@ namespace ZendTest\AuraDi\Config;
 use Psr\Container\ContainerInterface;
 use Zend\AuraDi\Config\Config;
 use Zend\AuraDi\Config\ContainerFactory;
+use Zend\ContainerTest\AliasTestTrait;
+use Zend\ContainerTest\FactoryTestTrait;
 use Zend\ContainerTest\InvokableTestTrait;
 
 class ContainerTest extends \Zend\ContainerTest\ContainerTest
 {
+    use AliasTestTrait;
+    use FactoryTestTrait;
     use InvokableTestTrait;
 
     protected function createContainer(array $config) : ContainerInterface


### PR DESCRIPTION
Using external library with common test to deliver the same functionality for specific service manager configuration keys.

For now we test only:
- `aliases`
- `invokables`
- `factories`

TODO:
- [ ] `services` (implemented, check if behaviour is the same as in ServiceManager)
- [ ] `delegators` (implemented, check if behaviour is the same as in ServiceManager)
- [ ] `abstract_factories` (we need decide if we'd like to support them)
- [ ] `initializers` (we need decide if we'd like to support them)
- [ ] `lazy_services` (we need decide if we'd like to support them)
- [x] ~`shared`~ - **AuraDi does not have ability to support non-shared services**
- [x] ~`shared_by_default`~ - **AuraDi does not have ability to support non-shared services**
